### PR TITLE
Move from Poison to Jason for JSON encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Stump is an Elixir log wrapper that allows you to pass Maps into the built in Lo
 Providing you with the ability to write more descriptive log messages and send logs to services expecting logs in the json/map format.
 The library is not limited to maps, it can also take in strings and create JSON formatted log messages.
 
+Please note, from Version 1.1 Stump will be using Jason as its JSON encoder. This will effect the ordering of logged items.
+
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
@@ -13,7 +15,7 @@ by adding `stump` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:stump, "~> 1.0.0"}
+    {:stump, "~> 1.1.0"}
   ]
 end
 ```

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -35,12 +35,12 @@ defmodule Stump do
   defp format(level, data) when is_map(data) do
     data
     |> Map.merge(%{datetime: time(), level: to_string(level)})
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   defp format(level, data) when is_bitstring(data) or is_binary(data) do
     %{message: data, datetime: time(), level: to_string(level)}
-    |> Poison.encode!()
+    |> Jason.encode!()
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Stump.MixProject do
   def project do
     [
       app: :stump,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.8",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Stump.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:poison, "~> 3.1"},
+      {:jason, "~> 1.1"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},

--- a/mix.lock
+++ b/mix.lock
@@ -4,6 +4,5 @@
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"}
 }

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -8,22 +8,22 @@ defmodule StumpTest do
   end
 
   test "when log level is valid but the message provided is '', it logs an error" do
-    assert capture_log(fn ->Stump.log(:error, "") end) == "{\"message\":\"Event Logger received log level, but no error message was provided\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:error, "") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
   end
 
   test "when log level is valid but the message provided is nil, it logs an error" do
-    assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"message\":\"Event Logger received log level, but no error message was provided\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
   end
 
   test "when log level is :info and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"message\":\"Here is some info\",\"level\":\"info\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\"}\n"
   end
 
   test "when log level is :warn and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->Stump.log(:warn, "This is a warning") end) == "{\"message\":\"This is a warning\",\"level\":\"warn\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:warn, "This is a warning") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"warn\",\"message\":\"This is a warning\"}\n"
   end
 
   test "when log level is :error and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->Stump.log(:error, "There was an error") end) == "{\"message\":\"There was an error\",\"level\":\"error\",\"datetime\":\"2019-03-01T00:00:00Z\"}\n"
+    assert capture_log(fn ->Stump.log(:error, "There was an error") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
   end
 end


### PR DESCRIPTION
In other applications we have found that the change from `Poison` to `Jason` increased the performance of the application. As logging increases in applications we don't want to risk hindering performance of any application just because they choose to log more.
This change should decrease `Stump`'s footprint in any project it is used.