### PR TITLE
Use non ! Jason.encode to save parent application

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by adding `stump` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:stump, "~> 1.1.0"}
+    {:stump, "~> 1.2.0"}
   ]
 end
 ```

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -46,8 +46,8 @@ defmodule Stump do
   defp encode(map) do
     case Jason.encode(map) do
       {:ok, value}    -> value
-      {:error, value} ->
-        encode(%{message: "There was an error encoding your log message: #{value.message}", datetime: time()})
+      {:error, encode_error} ->
+        encode(%{encoding_error_message: "There was an error encoding your log message: #{encode_error.message}", datetime: time()})
     end
   end
 

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -35,12 +35,20 @@ defmodule Stump do
   defp format(level, data) when is_map(data) do
     data
     |> Map.merge(%{datetime: time(), level: to_string(level)})
-    |> Jason.encode!()
+    |> encode()
   end
 
   defp format(level, data) when is_bitstring(data) or is_binary(data) do
     %{message: data, datetime: time(), level: to_string(level)}
-    |> Jason.encode!()
+    |> encode()
+  end
+
+  defp encode(map) do
+    case Jason.encode(map) do
+      {:ok, value}    -> value
+      {:error, value} ->
+        encode(%{message: "There was an error encoding your log message: #{value.message}", datetime: time()})
+    end
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Stump.MixProject do
   def project do
     [
       app: :stump,
-      version: "1.1.0",
+      version: "1.2.0",
       elixir: "~> 1.8",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -9,8 +9,8 @@ defmodule Stump.MixProject do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      description: description,
-      package: package
+      description: description(),
+      package: package()
     ]
   end
 

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -31,11 +31,11 @@ defmodule StumpTest do
 
   describe "failure" do
     test "when Stump receives data it cannot encode, it logs the error" do
-      assert capture_log(fn ->Stump.log(:error, <<0x80>>) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
+      assert capture_log(fn ->Stump.log(:error, <<0x80>>) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"encoding_error_message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
     end
 
     test "when Stump receives a map containing data it cannot encode, it logs the error" do
-      assert capture_log(fn ->Stump.log(:error, %{message: <<0x80>>}) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
+      assert capture_log(fn ->Stump.log(:error, %{message: <<0x80>>}) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"encoding_error_message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
     end
   end
 end

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -7,23 +7,35 @@ defmodule StumpTest do
     assert Stump.time == Stump.Time.MockTime.utc_now()
   end
 
-  test "when log level is valid but the message provided is '', it logs an error" do
-    assert capture_log(fn ->Stump.log(:error, "") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+  describe "sucess" do
+    test "when log level is valid but the message provided is '', it logs an error" do
+      assert capture_log(fn ->Stump.log(:error, "") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+    end
+
+    test "when log level is valid but the message provided is nil, it logs an error" do
+      assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+    end
+
+    test "when log level is :info and a message is provided it, it logs as JSON" do
+      assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\"}\n"
+    end
+
+    test "when log level is :warn and a message is provided it, it logs as JSON" do
+      assert capture_log(fn ->Stump.log(:warn, "This is a warning") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"warn\",\"message\":\"This is a warning\"}\n"
+    end
+
+    test "when log level is :error and a message is provided it, it logs as JSON" do
+      assert capture_log(fn ->Stump.log(:error, "There was an error") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
+    end
   end
 
-  test "when log level is valid but the message provided is nil, it logs an error" do
-    assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
-  end
+  describe "failure" do
+    test "when Stump receives data it cannot encode, it logs the error" do
+      assert capture_log(fn ->Stump.log(:error, <<0x80>>) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
+    end
 
-  test "when log level is :info and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\"}\n"
-  end
-
-  test "when log level is :warn and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->Stump.log(:warn, "This is a warning") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"warn\",\"message\":\"This is a warning\"}\n"
-  end
-
-  test "when log level is :error and a message is provided it, it logs as JSON" do
-    assert capture_log(fn ->Stump.log(:error, "There was an error") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
+    test "when Stump receives a map containing data it cannot encode, it logs the error" do
+      assert capture_log(fn ->Stump.log(:error, %{message: <<0x80>>}) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
+    end
   end
 end


### PR DESCRIPTION
When using the ! for both Jason and Poison .encode! the error would be raised causing the Logger to fail, the result of this was that the parent app using Stump could crash. This change should solve that
problem ensuring we don't forcibly raise the exception but instead log the error message we receive when trying to encode it.