### PR TITLE
Handle structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Stump
 [![Build Status](https://travis-ci.org/bbc/stump.svg?branch=master)](https://travis-ci.org/bbc/stump)
 
-Stump is an Elixir log wrapper that allows you to pass Maps into the built in Logger function, returning them in a JSON format and outputting to a file in Production mode.
+Stump is an Elixir log wrapper that allows you to pass Maps/Structs into the built in Logger function, returning them in a JSON format and outputting to a file in Production mode.
 Providing you with the ability to write more descriptive log messages and send logs to services expecting logs in the json/map format.
 The library is not limited to maps, it can also take in strings and create JSON formatted log messages.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ by adding `stump` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:stump, "~> 1.2.0"}
+    {:stump, "~> 1.3.0"}
   ]
 end
 ```

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -33,11 +33,8 @@ defmodule Stump do
   end
 
   defp format(level, %_{} = struct) do
-    struct
-    |> Map.from_struct()
-    |> Map.merge(%{datetime: time(), level: to_string(level)})
-    |> encode()
-
+    map = struct |> Map.from_struct()
+    format(level, map)
   end
 
   defp format(level, data) when is_map(data) do
@@ -53,9 +50,15 @@ defmodule Stump do
 
   defp encode(map) do
     case Jason.encode(map) do
-      {:ok, value}    -> value
+      {:ok, value} ->
+        value
+
       {:error, encode_error} ->
-        encode(%{encoding_error_message: "There was an error encoding your log message: #{encode_error.message}", datetime: time()})
+        encode(%{
+          encoding_error_message:
+            "There was an error encoding your log message: #{encode_error.message}",
+          datetime: time()
+        })
     end
   end
 

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -32,6 +32,14 @@ defmodule Stump do
     format(level, "Event Logger received log level, but no error message was provided")
   end
 
+  defp format(level, %_{} = struct) do
+    struct
+    |> Map.from_struct()
+    |> Map.merge(%{datetime: time(), level: to_string(level)})
+    |> encode()
+
+  end
+
   defp format(level, data) when is_map(data) do
     data
     |> Map.merge(%{datetime: time(), level: to_string(level)})

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -33,8 +33,7 @@ defmodule Stump do
   end
 
   defp format(level, %_{} = struct) do
-    map = struct |> Map.from_struct()
-    format(level, map)
+    format(level, Map.from_struct(struct))
   end
 
   defp format(level, data) when is_map(data) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Stump.MixProject do
   def project do
     [
       app: :stump,
-      version: "1.2.0",
+      version: "1.3.0",
       elixir: "~> 1.8",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env() == :prod,

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -1,4 +1,6 @@
 defmodule StumpTest do
+  defstruct message: "There was an error"
+
   use ExUnit.Case
   import ExUnit.CaptureLog
   require Logger
@@ -8,14 +10,6 @@ defmodule StumpTest do
   end
 
   describe "sucess" do
-    test "when log level is valid but the message provided is '', it logs an error" do
-      assert capture_log(fn ->Stump.log(:error, "") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
-    end
-
-    test "when log level is valid but the message provided is nil, it logs an error" do
-      assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
-    end
-
     test "when log level is :info and a message is provided it, it logs as JSON" do
       assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\"}\n"
     end
@@ -27,9 +21,26 @@ defmodule StumpTest do
     test "when log level is :error and a message is provided it, it logs as JSON" do
       assert capture_log(fn ->Stump.log(:error, "There was an error") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
     end
+
+    test "when Stump receives a map it encodes it and logs it" do
+      assert capture_log(fn ->Stump.log(:error, %{message: "There was an error"}) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
+    end
+
+    test "when Stump receives a struct it trasforms it to a map encodes it and logs it" do
+      assert capture_log(fn ->Stump.log(:error, %StumpTest{message: "This is the message from the struct"}) end) == 
+        "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"This is the message from the struct\"}\n"
+    end
   end
 
   describe "failure" do
+    test "when log level is valid but the message provided is '', it logs an error" do
+      assert capture_log(fn ->Stump.log(:error, "") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+    end
+
+    test "when log level is valid but the message provided is nil, it logs an error" do
+      assert capture_log(fn ->Stump.log(:error, nil) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+    end
+
     test "when Stump receives data it cannot encode, it logs the error" do
       assert capture_log(fn ->Stump.log(:error, <<0x80>>) end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"encoding_error_message\":\"There was an error encoding your log message: invalid byte 0x80 in <<128>>\"}\n"
     end

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -9,7 +9,7 @@ defmodule StumpTest do
     assert Stump.time == Stump.Time.MockTime.utc_now()
   end
 
-  describe "sucess" do
+  describe "success" do
     test "when log level is :info and a message is provided it, it logs as JSON" do
       assert capture_log(fn ->Stump.log(:info, "Here is some info") end) == "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\"}\n"
     end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(trace: true)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start(trace: true)
+ExUnit.start()


### PR DESCRIPTION
Due to Jason.encoder not supporting owned Structs out of the Box we need to ensure that when we receive a Struct we will turn it into a Map before we try and encode it.

Without this we actually raise a `%Protocol.UndefinedError` due to https://github.com/michalmuskala/jason#differences-to-poison:
> no support for encoding arbitrary structs - explicit implementation of the Jason.Encoder protocol is always required.

We could try and catch this error and return a helpful message instead but I think its unnecessary if we are just going to catch the Struct and turn it into a Map anyways.