### PR TITLE
RESFRAME-3219 Stump now can log metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# The directory Mix will write compiled artifacts to.
+# The directories Mix will write compiled artifacts to.
 /_build/
+.elixir_ls/
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
@@ -21,4 +22,6 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 stump-*.tar
+
+
 

--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -28,6 +28,14 @@ defmodule Stump do
     Logger.log(level, format(level, data))
   end
 
+  def metadata(keyword) do
+    Logger.metadata(keyword)
+  end
+
+  def metadata() do
+    Map.new(Logger.metadata())
+  end
+
   defp format(level, data) when data == nil or data == "" do
     format(level, "Event Logger received log level, but no error message was provided")
   end
@@ -39,12 +47,12 @@ defmodule Stump do
   defp format(level, data) when is_map(data) do
     data
     |> destruct()
-    |> Map.merge(%{datetime: time(), level: to_string(level)})
+    |> Map.merge(%{datetime: time(), level: to_string(level), metadata: metadata()})
     |> encode()
   end
 
   defp format(level, data) when is_bitstring(data) or is_binary(data) do
-    %{message: data, datetime: time(), level: to_string(level)}
+    %{message: data, datetime: time(), level: to_string(level), metadata: metadata()}
     |> encode()
   end
 

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -12,29 +12,29 @@ defmodule StumpTest do
   describe "success" do
     test "when log level is :info and a message is provided it, it logs as JSON" do
       assert capture_log(fn -> Stump.log(:info, "Here is some info") end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"Here is some info\",\"metadata\":{}}\n"
     end
 
     test "when log level is :warn and a message is provided it, it logs as JSON" do
       assert capture_log(fn -> Stump.log(:warn, "This is a warning") end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"warn\",\"message\":\"This is a warning\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"warn\",\"message\":\"This is a warning\",\"metadata\":{}}\n"
     end
 
     test "when log level is :error and a message is provided it, it logs as JSON" do
       assert capture_log(fn -> Stump.log(:error, "There was an error") end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\",\"metadata\":{}}\n"
     end
 
     test "when Stump receives a map it encodes it and logs it" do
       assert capture_log(fn -> Stump.log(:error, %{message: "There was an error"}) end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"There was an error\",\"metadata\":{}}\n"
     end
 
     test "when Stump receives a struct it trasforms it to a map encodes it and logs it" do
       assert capture_log(fn ->
                Stump.log(:error, %StumpTest{message: "This is the message from the struct"})
              end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"This is the message from the struct\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"This is the message from the struct\",\"metadata\":{}}\n"
     end
 
     test "when Stump receives nested structs it recursively turns them into maps to avoid Jason errors" do
@@ -44,43 +44,50 @@ defmodule StumpTest do
                  struct: %StumpTest{message: "I am a struct"}
                })
              end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"This is an error\",\"struct\":{\"message\":\"I am a struct\"}}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"This is an error\",\"metadata\":{},\"struct\":{\"message\":\"I am a struct\"}}\n"
     end
 
     test "When receiving a Map containing a tuple, it converts the tuple into a list" do
       assert capture_log(fn ->
                Stump.log(:error, %{tuple: {:this_is, "a tuple"}})
              end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"tuple\":[\"this_is\",\"a tuple\"]}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"metadata\":{},\"tuple\":[\"this_is\",\"a tuple\"]}\n"
     end
 
     test "When receiving a Map containing a List containing a tuple, it converts the tuple inside the list into a list" do
       assert capture_log(fn ->
                Stump.log(:error, %{list: [1, 2, 3, {:this_is, "a tuple"}]})
              end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"list\":[1,2,3,[\"this_is\",\"a tuple\"]]}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"list\":[1,2,3,[\"this_is\",\"a tuple\"]],\"metadata\":{}}\n"
+    end
+
+    test "When using Stump.metadata subsequent logs are labeled with said metadata" do
+      Stump.metadata(metadata_label: "some_metadata")
+
+      assert capture_log(fn -> Stump.log(:info, "There will be metadata with this!") end) ==
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"There will be metadata with this!\",\"metadata\":{\"metadata_label\":\"some_metadata\"}}\n"
     end
   end
 
   describe "failure" do
     test "when log level is valid but the message provided is '', it logs an error" do
       assert capture_log(fn -> Stump.log(:error, "") end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\",\"metadata\":{}}\n"
     end
 
     test "when log level is valid but the message provided is nil, it logs an error" do
       assert capture_log(fn -> Stump.log(:error, nil) end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"message\":\"Event Logger received log level, but no error message was provided\",\"metadata\":{}}\n"
     end
 
     test "when Stump receives data it cannot encode, it logs the error" do
       assert capture_log(fn -> Stump.log(:error, <<0x80>>) end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: #DateTime<2019-03-01 00:00:00Z>, level: \\\"error\\\", message: <<128>>}\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: #DateTime<2019-03-01 00:00:00Z>, level: \\\"error\\\", message: <<128>>, metadata: %{}}\"}\n"
     end
 
     test "when Stump receives a map containing data it cannot encode, it logs the error" do
       assert capture_log(fn -> Stump.log(:error, %{message: <<0x80>>}) end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: #DateTime<2019-03-01 00:00:00Z>, level: \\\"error\\\", message: <<128>>}\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: #DateTime<2019-03-01 00:00:00Z>, level: \\\"error\\\", message: <<128>>, metadata: %{}}\"}\n"
     end
   end
 end


### PR DESCRIPTION
JIRA: https://jira.dev.bbc.co.uk/browse/RESFRAME-3219

This is just a small change, but **required changing 14 of the 12 tests**, so I'd like to make another ticket about **refactoring those**. Apart from that its a small change as part of logging the path in belfrage.

~I upgraded the elixir version from 1.8 to 1.9 too as the default inspection of data types has gone from object string e.g. `DateTime<a-date>` to sigils e.g. `~U[a-date]`, travis was failing because it was testing on version 1.8 and expecting an object string rather than a sigil.~