### PR TITLE
Datetimes and refs

### DIFF
--- a/lib/stump.ex
+++ b/lib/stump.ex
@@ -76,6 +76,14 @@ defmodule Stump do
     Enum.map(data, fn x -> destruct(x) end)
   end
 
+  defp destruct(data) when is_reference(data) do
+    "#Ref<>"
+  end
+
+  defp destruct(data) when is_pid(data) do
+    "#Pid<>"
+  end
+
   defp destruct(data), do: data
 
   defp encode(map) do

--- a/lib/stump/time/date_time.ex
+++ b/lib/stump/time/date_time.ex
@@ -8,6 +8,6 @@ defmodule Stump.Time.DateTime do
   import DateTime, only: [utc_now: 0]
 
   def utc_now() do
-    DateTime.utc_now()
+    DateTime.utc_now() |> DateTime.to_iso8601()
   end
 end

--- a/lib/stump/time/mock_time.ex
+++ b/lib/stump/time/mock_time.ex
@@ -8,6 +8,6 @@ defmodule Stump.Time.MockTime do
 
   def utc_now() do
     # It's always 1st March 2019
-    DateTime.from_unix!(01_551_398_400)
+    DateTime.from_unix!(01_551_398_400) |> DateTime.to_iso8601()
   end
 end

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -82,12 +82,12 @@ defmodule StumpTest do
 
     test "when Stump receives data it cannot encode, it logs the error" do
       assert capture_log(fn -> Stump.log(:error, <<0x80>>) end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: #DateTime<2019-03-01 00:00:00Z>, level: \\\"error\\\", message: <<128>>, metadata: %{}}\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: \\\"2019-03-01T00:00:00Z\\\", level: \\\"error\\\", message: <<128>>, metadata: %{}}\"}\n"
     end
 
     test "when Stump receives a map containing data it cannot encode, it logs the error" do
       assert capture_log(fn -> Stump.log(:error, %{message: <<0x80>>}) end) ==
-               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: #DateTime<2019-03-01 00:00:00Z>, level: \\\"error\\\", message: <<128>>, metadata: %{}}\"}\n"
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"jason_error\":\"Jason returned an error encoding your log message\",\"raw_log\":\"%{datetime: \\\"2019-03-01T00:00:00Z\\\", level: \\\"error\\\", message: <<128>>, metadata: %{}}\"}\n"
     end
   end
 end

--- a/test/event_logger_test.exs
+++ b/test/event_logger_test.exs
@@ -67,6 +67,20 @@ defmodule StumpTest do
       assert capture_log(fn -> Stump.log(:info, "There will be metadata with this!") end) ==
                "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"info\",\"message\":\"There will be metadata with this!\",\"metadata\":{\"metadata_label\":\"some_metadata\"}}\n"
     end
+
+    test "When receiving a tuple containing an Elixir Reference replace it with a placeholder" do
+      assert capture_log(fn ->
+               Stump.log(:error, %{show_a_ref: make_ref()})
+             end) ==
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"metadata\":{},\"show_a_ref\":\"#Ref<>\"}\n"
+    end
+
+    test "When receiving a tuple containing a Pid replace it with a placeholder" do
+      assert capture_log(fn ->
+               Stump.log(:error, %{show_a_pid: self()})
+             end) ==
+               "{\"datetime\":\"2019-03-01T00:00:00Z\",\"level\":\"error\",\"metadata\":{},\"show_a_pid\":\"#Pid<>\"}\n"
+    end
   end
 
   describe "failure" do


### PR DESCRIPTION
Two little improvements with this PR:

Redacts Pids and References from the generated output as Jason is unable to encode them to valid JSON.

Also current Master does not pass on 1.9. Elixir is changing in the way it represents DateTimes, [1.9 has introduced a new ~U sigil](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/) for working with UTC DateTimes and [1.10 is adding more changes](https://elixir-lang.org/blog/2020/01/27/elixir-v1-10-0-released/). 

This PR proposes to use [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) strings for DateTimes,  even when logging encoding errors.

