### PR TITLE
Update to Version 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ by adding `stump` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:stump, "~> 1.5.0"}
+    {:stump, "~> 1.7.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Stump.MixProject do
   def project do
     [
       app: :stump,
-      version: "1.6.2",
+      version: "1.7",
       elixir: "~> 1.8",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Updates the version of Stump to 1.7.0 following the changes in this PR: https://github.com/bbc/stump/pull/14